### PR TITLE
[EamonKyle]Json step4

### DIFF
--- a/jsonparser/public/js/Lexer.js
+++ b/jsonparser/public/js/Lexer.js
@@ -1,49 +1,46 @@
-const _ = require("./utils");
+const _ = require('./utils');
 
 const switchSign = (value) => {
   switch (value) {
-    case "[":
-      return { type: "openArray", value };
-    case "]":
-      return { type: "closeArray", value };
-    case "{":
-      return { type: "openObject", value };
-    case "}":
-      return { type: "closeObject", value };
-    case ":":
-      return { type: "objSeparator", value };
-    case "null":
-    case "NULL":
-      return { type: "null", value };
-    case "true":
-    case "false":
-      return { type: "Boolean", value };
-    case "undefined":
-      return { type: "undefined", value };
+    case '[':
+      return { type: 'Array', subType: 'open', value };
+    case ']':
+      return { type: 'Array', subType: 'close', value };
+    case '{':
+      return { type: 'Object', subType: 'open', value };
+    case '}':
+      return { type: 'Object', subType: 'close', value };
+    case ':':
+      return { type: 'objSeparator', value };
+    case 'null':
+    case 'NULL':
+      return { type: 'null', value };
+    case 'true':
+    case 'false':
+      return { type: 'Boolean', value };
+    case 'undefined':
+      return { type: 'undefined', value };
   }
 };
 
 const isString = (value) => value[0] === '"';
 const isNumber = (value) => !isNaN(parseInt(value));
-const isObjSeparator = (value) => value === ":";
+const isObjSeparator = (value) => value === ':';
 
 const checkType = (value, isKey = false) => {
-  if (isKey) return { type: "String", value };
-  if (isNumber(value)) return { type: "Number", value };
-  if (isString(value)) return { type: "String", value };
+  if (isKey) return { type: 'String', value };
+  if (isNumber(value)) return { type: 'Number', value };
+  if (isString(value)) return { type: 'String', value };
   return switchSign(value);
 };
 
 const objTypeParser = (arr) =>
   arr.map((v, idx) => {
-    if (arr[idx + 1] && arr[idx + 1].type === "objSeparator")
-      v["objType"] = "propKey";
-    if (arr[idx - 1] && arr[idx - 1].type === "objSeparator")
-      v["objType"] = "propValue";
-      
+    if (arr[idx + 1] && arr[idx + 1].type === 'objSeparator') v['subType'] = 'propKey';
+    if (arr[idx - 1] && arr[idx - 1].type === 'objSeparator') v['subType'] = 'propValue';
+
     return v;
   });
-
 
 const preLexer = (arr) =>
   arr.map((value, idx, originArr) => {
@@ -51,15 +48,13 @@ const preLexer = (arr) =>
     else return checkType(value);
   });
 
-
-
 const stringParser = (arr) =>
-  arr.map(({ type, value }) => {
-    value = value.replace(/^"/gi, "").replace(/"$/gi, "");
-    return { type, value };
+  arr.map(({ type, value, subType }) => {
+    value = value.replace(/^"/gi, '').replace(/"$/gi, '');
+    return { type, value, subType };
   });
 
+const objSeparatorFilter = (arr) => arr.filter(({ type }) => type !== 'objSeparator');
 
-
-const lexer = _.pipe(preLexer, stringParser, objTypeParser);
+const lexer = _.pipe(preLexer, stringParser, objTypeParser, objSeparatorFilter);
 module.exports = lexer;

--- a/jsonparser/public/js/Lexer.js
+++ b/jsonparser/public/js/Lexer.js
@@ -17,7 +17,7 @@ const checkType = ({ value, isKey = false }) => {
 
 const preLexer = (arr) => {
   const preLexed = arr.map((value, idx) => {
-    if (isType.objSeparator(arr[idx + 1])) return checkType({ value, isKey: true });
+    if (is.objSeparator(arr[idx + 1])) return checkType({ value, isKey: true });
     else return checkType({ value });
   });
   return preLexed;
@@ -25,7 +25,9 @@ const preLexer = (arr) => {
 
 const objTypeParser = (arr) => {
   const objTypeParsed = arr.map((v, idx) => {
-    if (arr[idx + 1] && isType.objSeparator(arr[idx + 1].type)) v['subType'] = 'propKey';
+    if (arr[idx + 1] && isType.objSeparator(arr[idx + 1].type)) {
+      v['subType'] = 'propKey';
+    }
     if (arr[idx - 1] && isType.objSeparator(arr[idx - 1].type)) v['subType'] = 'propValue';
     return v;
   });

--- a/jsonparser/public/js/Lexer.js
+++ b/jsonparser/public/js/Lexer.js
@@ -9,7 +9,7 @@ const checkType = ({ value, isKey = false }) => {
   if (is.closeArray(value)) return { type: 'Array', subType: 'close' };
   if (is.openObject(value)) return { type: 'Object', subType: 'open' };
   if (is.closeObject(value)) return { type: 'Object', subType: 'close' };
-  if (is.objSeparator(value)) return { type: 'objSeparator' };
+  if (is.colon(value)) return { type: 'objSeparator' };
   if (is.null(value)) return { type: 'null', value: null };
   if (is.boolean(value)) return { type: 'Boolean', value: value === 'true' ? true : false };
   if (is.undefined(value)) return { type: 'undefined', value: undefined };
@@ -17,7 +17,7 @@ const checkType = ({ value, isKey = false }) => {
 
 const preLexer = (arr) => {
   const preLexed = arr.map((value, idx) => {
-    if (is.objSeparator(arr[idx + 1])) return checkType({ value, isKey: true });
+    if (is.colon(arr[idx + 1])) return checkType({ value, isKey: true });
     else return checkType({ value });
   });
   return preLexed;

--- a/jsonparser/public/js/Lexer.js
+++ b/jsonparser/public/js/Lexer.js
@@ -1,66 +1,38 @@
 const _ = require('./utils');
+const { is, isType } = require('./checkType.js');
 
-const isString = (value) => value[0] === '"';
-const isNumber = (value) => !isNaN(parseInt(value));
-const isObjSeparator = (value) => value === ':';
-
-const switchSign = (value) => {
-  switch (value) {
-    case '[':
-      return { type: 'Array', subType: 'open' };
-    case ']':
-      return { type: 'Array', subType: 'close' };
-    case '{':
-      return { type: 'Object', subType: 'open' };
-    case '}':
-      return { type: 'Object', subType: 'close' };
-    case ':':
-      return { type: 'objSeparator' };
-    case 'null':
-    case 'NULL':
-      return { type: 'null', value: null };
-    case 'true':
-      return { type: 'Boolean', value: true };
-    case 'false':
-      return { type: 'Boolean', value: false };
-    case 'undefined':
-      return { type: 'undefined', value: undefined };
-  }
-};
-
-const checkType = (value, isKey = false) => {
+const checkType = ({ value, isKey = false }) => {
   if (isKey) return { type: 'String', value };
-  if (isNumber(value)) return { type: 'Number', value: parseFloat(value) };
-  if (isString(value)) return { type: 'String', value };
-  return switchSign(value);
+  if (is.number(value)) return { type: 'Number', value: parseFloat(value) };
+  if (is.string(value)) return { type: 'String', value: value.slice(1, -1) };
+  if (is.openArray(value)) return { type: 'Array', subType: 'open' };
+  if (is.closeArray(value)) return { type: 'Array', subType: 'close' };
+  if (is.openObject(value)) return { type: 'Object', subType: 'open' };
+  if (is.closeObject(value)) return { type: 'Object', subType: 'close' };
+  if (is.objSeparator(value)) return { type: 'objSeparator' };
+  if (is.null(value)) return { type: 'null', value: null };
+  if (is.boolean(value)) return { type: 'Boolean', value: value === 'true' ? true : false };
+  if (is.undefined(value)) return { type: 'undefined', value: undefined };
 };
 
 const preLexer = (arr) => {
-  const preLexed = arr.map((value, idx, originArr) => {
-    if (isObjSeparator(originArr[idx + 1])) return checkType(value, true);
-    else return checkType(value);
+  const preLexed = arr.map((value, idx) => {
+    if (isType.objSeparator(arr[idx + 1])) return checkType({ value, isKey: true });
+    else return checkType({ value });
   });
   return preLexed;
 };
 
-const stringParser = (arr) => {
-  const stringParsed = arr.map((v) => {
-    if (v.type === 'String') v.value = v.value.replace(/^"/gi, '').replace(/"$/gi, '');
-    return v;
-  });
-  return stringParsed;
-};
-
 const objTypeParser = (arr) => {
   const objTypeParsed = arr.map((v, idx) => {
-    if (arr[idx + 1] && arr[idx + 1].type === 'objSeparator') v['subType'] = 'propKey';
-    if (arr[idx - 1] && arr[idx - 1].type === 'objSeparator') v['subType'] = 'propValue';
+    if (arr[idx + 1] && isType.objSeparator(arr[idx + 1].type)) v['subType'] = 'propKey';
+    if (arr[idx - 1] && isType.objSeparator(arr[idx - 1].type)) v['subType'] = 'propValue';
     return v;
   });
   return objTypeParsed;
 };
 
-const objSeparatorFilter = (arr) => arr.filter(({ type }) => type !== 'objSeparator');
+const objSeparatorFilter = (arr) => arr.filter(({ type }) => !isType.objSeparator(type));
 
-const lexer = _.pipe(preLexer, stringParser, objTypeParser, objSeparatorFilter);
+const lexer = _.pipe(preLexer, objTypeParser, objSeparatorFilter);
 module.exports = lexer;

--- a/jsonparser/public/js/Lexer.js
+++ b/jsonparser/public/js/Lexer.js
@@ -1,58 +1,64 @@
 const _ = require('./utils');
 
-const switchSign = (value) => {
-  switch (value) {
-    case '[':
-      return { type: 'Array', subType: 'open', value };
-    case ']':
-      return { type: 'Array', subType: 'close', value };
-    case '{':
-      return { type: 'Object', subType: 'open', value };
-    case '}':
-      return { type: 'Object', subType: 'close', value };
-    case ':':
-      return { type: 'objSeparator', value };
-    case 'null':
-    case 'NULL':
-      return { type: 'null', value };
-    case 'true':
-    case 'false':
-      return { type: 'Boolean', value };
-    case 'undefined':
-      return { type: 'undefined', value };
-  }
-};
-
 const isString = (value) => value[0] === '"';
 const isNumber = (value) => !isNaN(parseInt(value));
 const isObjSeparator = (value) => value === ':';
 
+const switchSign = (value) => {
+  switch (value) {
+    case '[':
+      return { type: 'Array', subType: 'open' };
+    case ']':
+      return { type: 'Array', subType: 'close' };
+    case '{':
+      return { type: 'Object', subType: 'open' };
+    case '}':
+      return { type: 'Object', subType: 'close' };
+    case ':':
+      return { type: 'objSeparator' };
+    case 'null':
+    case 'NULL':
+      return { type: 'null', value: null };
+    case 'true':
+      return { type: 'Boolean', value: true };
+    case 'false':
+      return { type: 'Boolean', value: false };
+    case 'undefined':
+      return { type: 'undefined', value: undefined };
+  }
+};
+
 const checkType = (value, isKey = false) => {
   if (isKey) return { type: 'String', value };
-  if (isNumber(value)) return { type: 'Number', value };
+  if (isNumber(value)) return { type: 'Number', value: parseFloat(value) };
   if (isString(value)) return { type: 'String', value };
   return switchSign(value);
 };
 
-const objTypeParser = (arr) =>
-  arr.map((v, idx) => {
-    if (arr[idx + 1] && arr[idx + 1].type === 'objSeparator') v['subType'] = 'propKey';
-    if (arr[idx - 1] && arr[idx - 1].type === 'objSeparator') v['subType'] = 'propValue';
-
-    return v;
-  });
-
-const preLexer = (arr) =>
-  arr.map((value, idx, originArr) => {
+const preLexer = (arr) => {
+  const preLexed = arr.map((value, idx, originArr) => {
     if (isObjSeparator(originArr[idx + 1])) return checkType(value, true);
     else return checkType(value);
   });
+  return preLexed;
+};
 
-const stringParser = (arr) =>
-  arr.map(({ type, value, subType }) => {
-    value = value.replace(/^"/gi, '').replace(/"$/gi, '');
-    return { type, value, subType };
+const stringParser = (arr) => {
+  const stringParsed = arr.map((v) => {
+    if (v.type === 'String') v.value = v.value.replace(/^"/gi, '').replace(/"$/gi, '');
+    return v;
   });
+  return stringParsed;
+};
+
+const objTypeParser = (arr) => {
+  const objTypeParsed = arr.map((v, idx) => {
+    if (arr[idx + 1] && arr[idx + 1].type === 'objSeparator') v['subType'] = 'propKey';
+    if (arr[idx - 1] && arr[idx - 1].type === 'objSeparator') v['subType'] = 'propValue';
+    return v;
+  });
+  return objTypeParsed;
+};
 
 const objSeparatorFilter = (arr) => arr.filter(({ type }) => type !== 'objSeparator');
 

--- a/jsonparser/public/js/Parser.js
+++ b/jsonparser/public/js/Parser.js
@@ -1,6 +1,8 @@
+const { is, isType } = require('./checkType.js');
+
 function makeNode({ type, value, subType }) {
-  if (type === 'Array' || type === 'Object' || type === 'init') return { type, child: [] };
-  else if (subType === 'propKey')
+  if (isType.array(type) || isType.object(type) || isType.init(type)) return { type, child: [] };
+  else if (isType.propKey(subType))
     return { value: { propKey: { type, value }, propValue: {} }, type: 'objectProperty' };
   else return { type, value };
 }
@@ -8,32 +10,31 @@ function makeNode({ type, value, subType }) {
 const preParser = (arr, node) => {
   for (let i = 0; i < arr.length; i++) {
     const value = arr[i];
-    switch (value.subType) {
-      case 'open':
-        const parentNode = makeNode(value);
-        const newNode = preParser(arr.slice(i + 1), parentNode);
-        i += newNode.skipIndex;
-        node.child.push(newNode.node);
-        break;
-      case 'close':
-        return { node, skipIndex: i + 1 };
-      case 'propKey':
-        const nextValue = arr[i + 1];
-        const objNode = makeNode(value);
-        const objProperyValueNode = makeNode(nextValue); //{type:array, child : []}
-        if (nextValue.type === 'Array' || nextValue.type === 'Object') {
-          const newValueNode = preParser(arr.slice(i + 2), objProperyValueNode);
-          objNode.value.propValue = newValueNode.node;
-          node.child.push(objNode);
-          i += newValueNode.skipIndex;
-        } else {
-          objNode.value.propValue = objProperyValueNode;
-          node.child.push(objNode);
-          i += 1;
-        }
-        break;
-      default:
-        node.child.push(makeNode(value));
+    const subType = value.subType;
+    if (isType.open(subType)) {
+      const parentNode = makeNode(value);
+      const newNode = preParser(arr.slice(i + 1), parentNode);
+      i += newNode.skipIndex;
+      node.child.push(newNode.node);
+    } else if (isType.close(subType)) {
+      return { node, skipIndex: i + 1 };
+    } else if (isType.propKey(subType)) {
+      const nextValue = arr[i + 1];
+      const objPropertyNode = makeNode(value);
+      const objProperyValueNode = makeNode(nextValue);
+      //Object value가 배열 또는 객체일 경우에는 재귀돌려서 결과를 만들어낸다.
+      if (isType.array(nextValue.type) || isType.object(nextValue.type)) {
+        const newValueNode = preParser(arr.slice(i + 2), objProperyValueNode);
+        objPropertyNode.value.propValue = newValueNode.node;
+        node.child.push(objPropertyNode);
+        i += newValueNode.skipIndex;
+      } else {
+        objPropertyNode.value.propValue = objProperyValueNode;
+        node.child.push(objPropertyNode);
+        i += 1;
+      }
+    } else {
+      node.child.push(makeNode(value));
     }
   }
 };
@@ -41,7 +42,7 @@ const preParser = (arr, node) => {
 const parser = (arr) => {
   const initNode = makeNode({ type: 'init' });
   preParser(arr, initNode);
-  return initNode.child;
+  return initNode.child[0];
 };
 
 module.exports = parser;

--- a/jsonparser/public/js/Parser.js
+++ b/jsonparser/public/js/Parser.js
@@ -1,4 +1,4 @@
-const { is, isType } = require('./checkType.js');
+const { isType } = require('./checkType.js');
 
 function makeNode({ type, value, subType }) {
   if (isType.array(type) || isType.object(type) || isType.init(type)) return { type, child: [] };
@@ -10,15 +10,14 @@ function makeNode({ type, value, subType }) {
 const preParser = (arr, node) => {
   for (let i = 0; i < arr.length; i++) {
     const value = arr[i];
-    const subType = value.subType;
-    if (isType.open(subType)) {
+    if (isType.open(value.subType)) {
       const parentNode = makeNode(value);
       const newNode = preParser(arr.slice(i + 1), parentNode);
       i += newNode.skipIndex;
       node.child.push(newNode.node);
-    } else if (isType.close(subType)) {
+    } else if (isType.close(value.subType)) {
       return { node, skipIndex: i + 1 };
-    } else if (isType.propKey(subType)) {
+    } else if (isType.propKey(value.subType)) {
       const nextValue = arr[i + 1];
       const objPropertyNode = makeNode(value);
       const objProperyValueNode = makeNode(nextValue);

--- a/jsonparser/public/js/Parser.js
+++ b/jsonparser/public/js/Parser.js
@@ -1,29 +1,92 @@
-const preParser = (arr, stack) => {
-  if (!arr.length) return stack;
-  const cur = arr.shift();
-  console.log(cur);
-  switch (cur.type) {
-    case "openArray":
-      stack.push("Array");
+const Node = ({ type, value }) => {
+  if (type === 'init') return { type: 'init', child: [] };
+  else if (type === 'openArray') return { type: 'array', child: [] };
+  else return { type, value };
+};
 
+const preParser = (arr, node, prevNode) => {
+  if (!arr.length) return;
+  const curValue = arr.shift();
+  switch (curValue.type) {
+    case 'openArray':
+      const arrayNode = Node(curValue);
+      node.child.push(arrayNode);
+      preParser(arr, arrayNode, node);
+      preParser(arr, node, prevNode);
       break;
-    case "openObject":
-      stack.push("Obj");
-
-      break;
-    case "closeArray":
-      stack.pop();
-      break;
-    case "closeObject":
-      stack.pop();
+    case 'closeArray':
+      return;
+    default:
+      const valueNode = Node(curValue);
+      node.child.push(valueNode);
+      preParser(arr, node, prevNode);
       break;
   }
-  return preParser(arr, stack);
+};
+
+const preParser = (arr, node) => {
+  if (!arr.length) return;
+  const curValue = arr.shift();
+  switch (curValue.type) {
+    case 'openArray':
+      const arrayNode = Node(curValue);
+      const newNode = preParser(arr, arrayNode);
+      node.child.push(newNode);
+      preParser(arr, node);
+      break;
+    case 'closeArray':
+      return node;
+    default:
+      const valueNode = Node(curValue);
+      node.child.push(valueNode);
+      preParser(arr, node);
+      return node;
+  }
+};
+
+const preParser = (arr, node) => {
+  for (let i = 0; i < arr.length; i++) {
+    const value = arr[i];
+    switch (value.type) {
+      case 'openArray':
+        const arrayNode = Node(value);
+        const newNode = preParser(arr.slice(i + 1), arrayNode);
+        i += newNode.idx + 1;
+        node.child.push(newNode.node);
+        break;
+      case 'closeArray':
+        return { node, idx: i };
+      default:
+        node.child.push(Node(value));
+    }
+  }
 };
 
 const parser = (arr) => {
-  let stack = [];
-  console.log(preParser(arr, stack));
+  const initNode = Node({ type: 'init' });
+  preParser(arr, initNode);
+  return initNode.child;
 };
 
-module.exports = parser;
+// module.exports = parser;
+
+const test = [
+  { type: 'openArray', value: '[' },
+  { type: 'Number', value: '1' },
+  { type: 'openArray', value: '[' },
+  { type: 'Number', value: '2' },
+  { type: 'openArray', value: '[' },
+  { type: 'Number', value: '2' },
+  { type: 'openArray', value: '[' },
+  { type: 'Number', value: '2' },
+  { type: 'closeArray', value: ']' },
+  { type: 'Number', value: '3' },
+  { type: 'closeArray', value: ']' },
+  { type: 'Number', value: '1' },
+  { type: 'closeArray', value: ']' },
+  { type: 'Number', value: '2' },
+  { type: 'closeArray', value: ']' },
+];
+
+// [1, [2, [2, [2], 3], 1], 2];
+console.dir(parser(test), { depth: null });

--- a/jsonparser/public/js/Parser.js
+++ b/jsonparser/public/js/Parser.js
@@ -20,15 +20,15 @@ const preParser = (arr, node) => {
     } else if (isType.propKey(value.subType)) {
       const nextValue = arr[i + 1];
       const objPropertyNode = makeNode(value);
-      const objProperyValueNode = makeNode(nextValue);
+      const objPropertyValueNode = makeNode(nextValue);
       //Object value가 배열 또는 객체일 경우에는 재귀돌려서 결과를 만들어낸다.
       if (isType.array(nextValue.type) || isType.object(nextValue.type)) {
-        const newValueNode = preParser(arr.slice(i + 2), objProperyValueNode);
+        const newValueNode = preParser(arr.slice(i + 2), objPropertyValueNode);
         objPropertyNode.value.propValue = newValueNode.node;
         node.child.push(objPropertyNode);
         i += newValueNode.skipIndex;
       } else {
-        objPropertyNode.value.propValue = objProperyValueNode;
+        objPropertyNode.value.propValue = objPropertyValueNode;
         node.child.push(objPropertyNode);
         i += 1;
       }

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -17,7 +17,7 @@ const isStringSign = (value) => value === "'" || value === '"';
 const isRealSign = (stringStack, value) => !stringStack.length && isSign(value);
 //구분자가 아닌 값인지 확인
 const isStartValue = (stringStack, value, preValue) =>
-  !stringStack.length && isSign(preValue) && !isStringSign(value);
+  !stringStack.length && isSign(preValue) && !isStringSign(value) && value !== ' ';
 //스트링 시작하는 따옴표인지 확인
 const isStartString = (stringStack, value) => !stringStack.length && isStringSign(value);
 //스트링 끝나는 따옴표인지 확인
@@ -44,9 +44,6 @@ const preTokenizer = (str) => {
 //양끝 공백 제거
 const arraySpaceParser = (arr) => arr.map((v) => v.trim());
 
-//빈 공백 제거
-const blankFilter = (arr) => arr.filter((v) => v !== '');
-
-const tokenizer = _.pipe(preTokenizer, arraySpaceParser, blankFilter);
+const tokenizer = _.pipe(preTokenizer, arraySpaceParser);
 
 module.exports = tokenizer;

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -1,6 +1,7 @@
 const _ = require('./utils.js');
 const lexer = require('./Lexer.js');
 const parser = require('./Parser.js');
+
 const isSign = (value) => {
   return (
     value === '[' ||
@@ -11,26 +12,18 @@ const isSign = (value) => {
     value === ':'
   );
 };
+//스트링 따옴표인지 확인
 const isStringSign = (value) => value === "'" || value === '"';
+//문자열에 포함되지 않는 구분자인지 확인
 const isRealSign = (stringStack, value) => !stringStack.length && isSign(value);
+//구분자가 아닌 값인지 확인
 const isStartValue = (stringStack, value, preValue) =>
   !stringStack.length && isSign(preValue) && !isStringSign(value);
+//스트링 시작하는 따옴표인지 확인
 const isStartString = (stringStack, value) => !stringStack.length && isStringSign(value);
-const isEndString = (stringStack, value) => value === stringStack[stringStack.length - 1];
-const arraySpaceParser = (arr) => arr.map((v) => v.trim());
-
-const arrayQuotesParser = (arr) => arr.map(quotesParser);
-
-const quotesParser = (value) => {
-  if (value[0] === "'" && value[value.length - 1] === "'") {
-    value = value
-      .split('')
-      .slice(1, value.length - 1)
-      .join('');
-    return '"' + value + '"';
-  }
-  return value;
-};
+//스트링 끝나는 따옴표인지 확인
+const isEndString = (stringStack, value, nextValue) =>
+  value === stringStack[stringStack.length - 1] && isSign(nextValue);
 
 const preTokenizer = (str) => {
   const stringStack = [];
@@ -40,7 +33,7 @@ const preTokenizer = (str) => {
       stringStack.push(cur);
       acc.push(cur);
       return acc;
-    } else if (isEndString(stringStack, cur)) stringStack.pop();
+    } else if (isEndString(stringStack, cur, arr[idx + 1])) stringStack.pop();
 
     if (isStartValue(stringStack, cur, arr[idx - 1]) || isRealSign(stringStack, cur)) acc.push(cur);
     else acc[acc.length - 1] += cur;
@@ -49,18 +42,20 @@ const preTokenizer = (str) => {
   }, []);
   return tokenArray;
 };
-
+//양끝 공백 제거
+const arraySpaceParser = (arr) => arr.map((v) => v.trim());
+const quotesParser = (value) => {
+  if (value[0] === "'" && value[value.length - 1] === "'") {
+    value = value.slice(1, value.length - 1);
+    return '"' + value + '"';
+  }
+  return value;
+};
+//문자열 양끝 따옴표 ' => "
+const arrayQuotesParser = (arr) => arr.map(quotesParser);
+//빈 공백 제거
 const blankFilter = (arr) => arr.filter((v) => v !== '');
 
 const tokenizer = _.pipe(preTokenizer, arraySpaceParser, arrayQuotesParser, blankFilter);
 
 module.exports = tokenizer;
-
-const main = _.pipe(tokenizer, lexer, parser);
-
-console.dir(
-  main(
-    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
-  ),
-  { depth: null }
-);

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -56,11 +56,11 @@ const tokenizer = _.pipe(preTokenizer, arraySpaceParser, arrayQuotesParser, blan
 
 module.exports = tokenizer;
 
-const main = _.pipe(tokenizer, lexer, parser);
+// const main = _.pipe(tokenizer, lexer, parser);
 
-console.dir(
-  main(
-    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
-  ),
-  { depth: null }
-);
+// console.dir(
+//   main(
+//     '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
+//   ),
+//   { depth: null }
+// );

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -43,18 +43,10 @@ const preTokenizer = (str) => {
 };
 //양끝 공백 제거
 const arraySpaceParser = (arr) => arr.map((v) => v.trim());
-const quotesParser = (value) => {
-  if (value[0] === "'" && value[value.length - 1] === "'") {
-    value = value.slice(1, value.length - 1);
-    return '"' + value + '"';
-  }
-  return value;
-};
-//문자열 양끝 따옴표 ' => "
-const arrayQuotesParser = (arr) => arr.map(quotesParser);
+
 //빈 공백 제거
 const blankFilter = (arr) => arr.filter((v) => v !== '');
 
-const tokenizer = _.pipe(preTokenizer, arraySpaceParser, arrayQuotesParser, blankFilter);
+const tokenizer = _.pipe(preTokenizer, arraySpaceParser, blankFilter);
 
 module.exports = tokenizer;

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -1,6 +1,6 @@
 const _ = require('./utils.js');
 const lexer = require('./Lexer.js');
-// const parser = require('./Parser.js');
+const parser = require('./Parser.js');
 const isSign = (value) => {
   return (
     value === '[' ||
@@ -54,6 +54,13 @@ const blankFilter = (arr) => arr.filter((v) => v !== '');
 
 const tokenizer = _.pipe(preTokenizer, arraySpaceParser, arrayQuotesParser, blankFilter);
 
-const main = _.pipe(tokenizer, lexer);
+module.exports = tokenizer;
 
-console.log(main(`[1,[2,3]]`));
+const main = _.pipe(tokenizer, lexer, parser);
+
+console.dir(
+  main(
+    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
+  ),
+  { depth: null }
+);

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -1,15 +1,14 @@
 const _ = require('./utils.js');
-const lexer = require('./Lexer.js');
-const parser = require('./Parser.js');
+const { is } = require('./checkType.js');
 
 const isSign = (value) => {
   return (
-    value === '[' ||
-    value === ',' ||
-    value === ']' ||
-    value === '{' ||
-    value === '}' ||
-    value === ':'
+    is.openArray(value) ||
+    is.closeArray(value) ||
+    is.openObject(value) ||
+    is.closeObject(value) ||
+    is.comma(value) ||
+    is.colon(value)
   );
 };
 //스트링 따옴표인지 확인

--- a/jsonparser/public/js/Tokenizer.js
+++ b/jsonparser/public/js/Tokenizer.js
@@ -1,24 +1,22 @@
-const _ = require("./utils.js");
-const lexer = require("./Lexer.js");
-const parser = require("./Parser.js");
+const _ = require('./utils.js');
+const lexer = require('./Lexer.js');
+// const parser = require('./Parser.js');
 const isSign = (value) => {
   return (
-    value === "[" ||
-    value === "," ||
-    value === "]" ||
-    value === "{" ||
-    value === "}" ||
-    value === ":"
+    value === '[' ||
+    value === ',' ||
+    value === ']' ||
+    value === '{' ||
+    value === '}' ||
+    value === ':'
   );
 };
 const isStringSign = (value) => value === "'" || value === '"';
 const isRealSign = (stringStack, value) => !stringStack.length && isSign(value);
 const isStartValue = (stringStack, value, preValue) =>
   !stringStack.length && isSign(preValue) && !isStringSign(value);
-const isStartString = (stringStack, value) =>
-  !stringStack.length && isStringSign(value);
-const isEndString = (stringStack, value) =>
-  value === stringStack[stringStack.length - 1];
+const isStartString = (stringStack, value) => !stringStack.length && isStringSign(value);
+const isEndString = (stringStack, value) => value === stringStack[stringStack.length - 1];
 const arraySpaceParser = (arr) => arr.map((v) => v.trim());
 
 const arrayQuotesParser = (arr) => arr.map(quotesParser);
@@ -26,9 +24,9 @@ const arrayQuotesParser = (arr) => arr.map(quotesParser);
 const quotesParser = (value) => {
   if (value[0] === "'" && value[value.length - 1] === "'") {
     value = value
-      .split("")
+      .split('')
       .slice(1, value.length - 1)
-      .join("");
+      .join('');
     return '"' + value + '"';
   }
   return value;
@@ -36,19 +34,15 @@ const quotesParser = (value) => {
 
 const preTokenizer = (str) => {
   const stringStack = [];
-  const tokenArray = str.split("").reduce((acc, cur, idx, arr) => {
-    if (cur === ",") return acc;
+  const tokenArray = str.split('').reduce((acc, cur, idx, arr) => {
+    if (cur === ',') return acc;
     if (isStartString(stringStack, cur)) {
       stringStack.push(cur);
       acc.push(cur);
       return acc;
     } else if (isEndString(stringStack, cur)) stringStack.pop();
 
-    if (
-      isStartValue(stringStack, cur, arr[idx - 1]) ||
-      isRealSign(stringStack, cur)
-    )
-      acc.push(cur);
+    if (isStartValue(stringStack, cur, arr[idx - 1]) || isRealSign(stringStack, cur)) acc.push(cur);
     else acc[acc.length - 1] += cur;
 
     return acc;
@@ -56,15 +50,10 @@ const preTokenizer = (str) => {
   return tokenArray;
 };
 
-const blankFilter = (arr) => arr.filter((v) => v !== "");
+const blankFilter = (arr) => arr.filter((v) => v !== '');
 
-const tokenizer = _.pipe(
-  preTokenizer,
-  arraySpaceParser,
-  arrayQuotesParser,
-  blankFilter
-);
+const tokenizer = _.pipe(preTokenizer, arraySpaceParser, arrayQuotesParser, blankFilter);
 
-const main = _.pipe(tokenizer, lexer, parser);
+const main = _.pipe(tokenizer, lexer);
 
-console.log(main(`[1]`));
+console.log(main(`[1,[2,3]]`));

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -3,11 +3,6 @@ const tokenizer = require('./Tokenizer.js');
 const lexer = require('./Lexer.js');
 const parser = require('./Parser.js');
 
-const jsonParser = _.pipe(tokenizer, lexer, parser);
+const jsonParser = _.pipe(tokenizer, lexer);
 
-console.dir(
-  jsonParser(
-    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
-  ),
-  { depth: null }
-);
+console.dir(jsonParser("[\"a\",['b','c']]"), { depth: null });

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -1,13 +1,8 @@
-const _ = require('./utils.js');
-const tokenizer = require('./Tokenizer.js');
-const lexer = require('./Lexer.js');
-const parser = require('./Parser.js');
+const _ = require("./utils.js");
+const tokenizer = require("./Tokenizer.js");
+const lexer = require("./Lexer.js");
+const parser = require("./Parser.js");
 
 const jsonParser = _.pipe(tokenizer, lexer, parser);
 
-console.dir(
-  jsonParser(
-    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
-  ),
-  { depth: null }
-);
+console.dir(jsonParser('["[name]hello",123,{a:1,b:[1,2,3]}]'), { depth: null });

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -3,6 +3,4 @@ const tokenizer = require('./Tokenizer.js');
 const lexer = require('./Lexer.js');
 const parser = require('./Parser.js');
 
-const jsonParser = _.pipe(tokenizer);
-
-console.dir(jsonParser('["a",  [\'3\',4]]'), { depth: null });
+const jsonParser = _.pipe(tokenizer, lexer, parser);

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -5,4 +5,4 @@ const parser = require('./Parser.js');
 
 const jsonParser = _.pipe(tokenizer, lexer);
 
-console.dir(jsonParser("[\"a\",['b','c']]"), { depth: null });
+console.dir(jsonParser('["a",[\'3\',4]]'), { depth: null });

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -3,6 +3,6 @@ const tokenizer = require('./Tokenizer.js');
 const lexer = require('./Lexer.js');
 const parser = require('./Parser.js');
 
-const jsonParser = _.pipe(tokenizer, lexer);
+const jsonParser = _.pipe(tokenizer);
 
-console.dir(jsonParser('["a",[\'3\',4]]'), { depth: null });
+console.dir(jsonParser('["a",  [\'3\',4]]'), { depth: null });

--- a/jsonparser/public/js/app.js
+++ b/jsonparser/public/js/app.js
@@ -1,0 +1,13 @@
+const _ = require('./utils.js');
+const tokenizer = require('./Tokenizer.js');
+const lexer = require('./Lexer.js');
+const parser = require('./Parser.js');
+
+const jsonParser = _.pipe(tokenizer, lexer, parser);
+
+console.dir(
+  jsonParser(
+    '["1a3",[null,false,["11",[112233],{"easy" : ["hello", {"a":"a"}, "world"]},112],55, "99"],{"a":"str", "b":[912,[5656,33],{"key" : "innervalue", "newkeys": [1,2,3,4,5]}]}, true]'
+  ),
+  { depth: null }
+);

--- a/jsonparser/public/js/checkType.js
+++ b/jsonparser/public/js/checkType.js
@@ -24,7 +24,7 @@ const is = {
     return !isNaN(parseInt(value));
   },
   string(value) {
-    return value[0] === '"';
+    return value[0] === '"' || value[0] === "'";
   },
   boolean(value) {
     return value === 'true' || value === 'false';

--- a/jsonparser/public/js/checkType.js
+++ b/jsonparser/public/js/checkType.js
@@ -1,0 +1,76 @@
+const is = {
+  openArray(value) {
+    return value === '[';
+  },
+  closeArray(value) {
+    return value === ']';
+  },
+  openObject(value) {
+    return value === '{';
+  },
+  closeObject(value) {
+    return value === '}';
+  },
+  colon(value) {
+    return value === ':';
+  },
+  comma(value) {
+    return value === ',';
+  },
+  null(value) {
+    return value === 'null' || value === 'NULL';
+  },
+  number(value) {
+    return !isNaN(parseInt(value));
+  },
+  string(value) {
+    return value[0] === '"';
+  },
+  boolean(value) {
+    return value === 'true' || value === 'false';
+  },
+  undefined(value) {
+    return value === 'undefined';
+  },
+  objSeparator(value) {
+    return value === ':';
+  },
+};
+
+const isType = {
+  init(type) {
+    return type === 'init';
+  },
+  open(type) {
+    return type === 'open';
+  },
+  close(type) {
+    return type === 'close';
+  },
+  propKey(type) {
+    return type === 'propKey';
+  },
+  array(type) {
+    return type === 'Array';
+  },
+  object(type) {
+    return type === 'Obejct';
+  },
+  number(type) {
+    return type === 'Number';
+  },
+  string(type) {
+    return type === 'String';
+  },
+  boolean(type) {
+    return type === 'Boolean';
+  },
+  objSeparator(value) {
+    return value === 'objSeparator';
+  },
+  propKey(value) {
+    return value === 'propKey';
+  },
+};
+
+module.exports = { is, isType };

--- a/jsonparser/public/js/checkType.js
+++ b/jsonparser/public/js/checkType.js
@@ -54,7 +54,7 @@ const isType = {
     return type === 'Array';
   },
   object(type) {
-    return type === 'Obejct';
+    return type === 'Object';
   },
   number(type) {
     return type === 'Number';
@@ -65,11 +65,11 @@ const isType = {
   boolean(type) {
     return type === 'Boolean';
   },
-  objSeparator(value) {
-    return value === 'objSeparator';
+  objSeparator(type) {
+    return type === 'objSeparator';
   },
-  propKey(value) {
-    return value === 'propKey';
+  propKey(type) {
+    return type === 'propKey';
   },
 };
 

--- a/jsonparser/public/js/checkType.js
+++ b/jsonparser/public/js/checkType.js
@@ -32,9 +32,6 @@ const is = {
   undefined(value) {
     return value === 'undefined';
   },
-  objSeparator(value) {
-    return value === ':';
-  },
 };
 
 const isType = {
@@ -67,9 +64,6 @@ const isType = {
   },
   objSeparator(type) {
     return type === 'objSeparator';
-  },
-  propKey(type) {
-    return type === 'propKey';
   },
 };
 

--- a/jsonparser/public/js/view.js
+++ b/jsonparser/public/js/view.js
@@ -1,0 +1,15 @@
+const arrayDepthCount = (json, cnt = 0, cntArr = []) => {
+  if (!json.child || json.type === "Object") return;
+  
+  cnt += 1;
+  cntArr.push(cnt);
+  json.child.forEach((v) => {
+    arrayDepthCount(v, cnt, cntArr);
+  });
+
+  return Math.max(...cntArr);
+};
+
+
+
+

--- a/jsonparser/public/js/view.js
+++ b/jsonparser/public/js/view.js
@@ -1,6 +1,8 @@
+const { is, isType } = require('./checkType.js');
+
 const arrayDepthCount = (json, cnt = 0, cntArr = []) => {
-  if (!json.child || json.type === "Object") return;
-  
+  if (!json.child || isType.object(json.type)) return;
+
   cnt += 1;
   cntArr.push(cnt);
   json.child.forEach((v) => {
@@ -10,6 +12,23 @@ const arrayDepthCount = (json, cnt = 0, cntArr = []) => {
   return Math.max(...cntArr);
 };
 
+const numStrCount = (json, numCnt = 0, strCnt = 0) => {
+  if (!json.child) return { numCnt, strCnt };
+  const childList = json.child;
 
-
-
+  childList.forEach((v) => {
+    let checkValue;
+    if (v.type === 'objectProperty') {
+      strCnt++; //key타입 더해주기
+      checkValue = v.value.propValue;
+    } else {
+      checkValue = v;
+    }
+    if (isType.number(checkValue.type)) numCnt++;
+    if (isType.string(checkValue.type)) strCnt++;
+    const stackCount = numStrCount(checkValue, numCnt, strCnt);
+    numCnt += stackCount.numCnt - numCnt;
+    strCnt += stackCount.strCnt - strCnt;
+  });
+  return { numCnt, strCnt };
+};


### PR DESCRIPTION
## 구현한 사항
- [x]  배열 중첩 개수 코드 ⇒ view.js
- [x]  string , number 갯수 ⇒ view.js
- [x]  lexer 에서 찐으로 바꾸기 ⇒ null , undifined , num, true false
- [x]  함수 순서 정리 ⇒ 리펙토링
- [ ]  에러처리
    - [ ]  ⇒ 1. 닫히는거 제대로 안닫칠때  ⇒ stack 으로 해결 `[ }` `[ [`
    - [ ]  ⇒ 2. 시작이 배열이나 오브젝트가 아니면 ⇒ error
    - [x]  ⇒ "hell\"o"

## jsonparser로직

![0001](https://user-images.githubusercontent.com/68339352/113310357-1cc9a100-9343-11eb-9aa5-4773ac7822e8.jpg)
![0002](https://user-images.githubusercontent.com/68339352/113310370-205d2800-9343-11eb-8eea-a0940fe503e7.jpg)

# Parser

subType기준으로 4가지 경우가 있다. 

- open: `[`, `{`

- close: `]`, `}`

- propKey: Object key

- 나머지: 스트링, 숫자, 불린, 널, 등등

### open일 때

1. 자신의 타입에 맞는 child를 갖는 객체를 생성한다. 현재 open이 close될 때까지 생성된 객체의 child에 값들이 담기게 된다.  (`{type,child:[]}`)

2. 현재 생성한 객체를 부모노드로 이용해 재귀호출한다.

   `preParser(배열, 부모노드) ` 

   - 배열: 현재 다음 index부터의 배열  `배열.slice(idx+1)`

   - 부모노드: 생성된 {type,child:[]}가 담겨서 재귀 호출이 실행된다. 

3. 반환된 `skipIndex`만큼 index를 더해준다.

4.  현재콜스택 부모 노드의 child에 반환된 node를 push한다.

### close일 때

현재 부모노드와 현재까지 진행된 `index+1`을 `skipIndex`로 반환한다. 

현재 콜스택에서 진행한 index의 값 +1 만큼을 반환해 상위 콜스택에서 진행한 부분 만큼은 skip할 수 있게 했다.


### propKey일 때 

객체의 키일 때는 Object value까지 이 단계에서 처리해준다. 그렇기 때문에 index skip처리에 신경 써야한다.

1. 현재 인덱스의 값 - Object key를 이용해서 `objectPropertyNode`를 생성 (`{ value: { propKey: { type, value }, propValue: {} }, type: 'objectProperty'} `)

3. 다음 인덱스의 값 - Object value를 이용해서 `objectPropertyValueNode`를 생성

    #### - Object value array,object 경우
	1. open처럼 재귀 후 반환된 node를 `objectPropertyNode.value.propValue`에 넣어준다.
    2. 현재콜스택 부모 노드의 child에 완성된  `objectPropertyNode`를 넣어준다.
    3. 반환된 `skipIndex+1`만큼 index를 더해준다.
    #### - 단순한 값일 경우
    1. Object value 노드를 만들어 `objectPropertyNode.value.propValue`에 넣어준다.
    2. 현재콜스택 부모 노드의 child에 완성된  `objectPropertyNode`를 넣어준다.
    3. Object value 하나만 추가로 처리했으니 i+1 해준다.

### 그 외 일반적인 값일 때 

현재콜스택 부모 노드의 child에 현재 값의 노드를 넣어준다. (`{ type, value }`)  
